### PR TITLE
xz: Don't run testsuite when cross-compiling

### DIFF
--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
-  doCheck = true;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   # In stdenv-linux, prevent a dependency on bootstrap-tools.
   preConfigure = "unset CONFIG_SHELL";


### PR DESCRIPTION
###### Motivation for this change

Allow it to cross compile.
