### PR TITLE
Slightly less hacky --compiler for callCabal2nix

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -119,7 +119,7 @@ let
       installPhase = ''
         export HOME="$TMP"
         mkdir -p "$out"
-        cabal2nix --compiler=${/*self.ghc.name*/"ghc-8.1"} --system=${stdenv.system} ${sha256Arg} "${src}" > "$out/default.nix"
+        cabal2nix --compiler=${if self.ghc.isGhcjs or false then "ghcjs" else "ghc"} --system=${stdenv.system} ${sha256Arg} "${src}" > "$out/default.nix"
       '';
   };
 


### PR DESCRIPTION
I noticed that `reflex-platform` will build dependencies with GHCJS that are supposed to be blocked by `if impl(ghcjs)` or the like.

@Ericson2314 This triggers a mass rebuild. Any idea why? Although the `haskellSrc2nix` derivations themselves should be changed, the expressions imported from there should be unchanged, so I wouldn't expect anything to need rebuilding. But it has to rebuild GHCJS, and a few of its dependencies.