### PR TITLE
Boostcrossfixtoolset

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -2,7 +2,6 @@
 , which
 , buildPackages, buildPlatform, hostPlatform
 , toolset ? /**/ if stdenv.cc.isClang                                then "clang"
-            else if stdenv.cc.isGNU && hostPlatform != buildPlatform then "gcc-cross"
             else null
 , enableRelease ? true
 , enableDebug ? false


### PR DESCRIPTION
###### Motivation for this change

configure fails for cross compilation because gcc-cross toolset does not exist. Note the "--without-python" fix is also included in this one. 

With this fix cross compilation of Boost 1.64 works. (Newer version need an update of the mingw patch they apply(

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

