### PR TITLE
Backport changes from nixos-20.09 to reflex-platform-20.05

### DIFF
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -2,7 +2,7 @@
 # default vimrc
 , vimrc ? fetchurl {
     name = "default-vimrc";
-    url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/archlinux.vim?id=68f6d131750aa778807119e03eed70286a17b1cb";
+    url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/68f6d131750aa778807119e03eed70286a17b1cb/trunk/archlinux.vim";
     sha256 = "18ifhv5q9prd175q3vxbqf6qyvkk6bc7d2lhqdk0q78i68kv9y0c";
   }
 # apple frameworks

--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   patches = [
     # Fixes build with exiv2 0.27.1
     (fetchpatch {
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/hugin-exiv2-0.27.1.patch?h=packages/hugin";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/0467d8ba362b9c196e4c1dc4be7de0c1b336335b/hugin/trunk/hugin-exiv2-0.27.1.patch";
       sha256 = "1yxvlpvrhyrfd2w6kwx1w3mncsvlzdhp0w7xchy8q6kc2kd5nf7r";
     })
   ];

--- a/pkgs/applications/office/abiword/default.nix
+++ b/pkgs/applications/office/abiword/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     # default and this patch can be removed.
     # https://github.com/NixOS/nixpkgs/issues/38506
     (fetchurl {
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/enchant-2.1.patch?h=packages/abiword";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/d3ff951d3c7249927e7113b3de1653031db24596/abiword/trunk/enchant-2.1.patch";
       sha256 = "444dc2aadea3c80310a509b690097541573f6d2652c573d04da66a0f385fcfb2";
     })
   ];

--- a/pkgs/applications/science/astronomy/xplanet/default.nix
+++ b/pkgs/applications/science/astronomy/xplanet/default.nix
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "giflib6.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/giflib6.patch?h=packages/xplanet&id=ce6f25eb369dc011161613894f01fd0a6ae85a09";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/ce6f25eb369dc011161613894f01fd0a6ae85a09/trunk/giflib6.patch";
       sha256 = "173l0xkqq0v2bpaff7hhwc7y2aw5cclqw8988k1nalhyfbrjb8bl";
     })
     (fetchpatch {
       name = "xplanet-c++11.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/xplanet-c++11.patch?h=packages/xplanet&id=ce6f25eb369dc011161613894f01fd0a6ae85a09";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/ce6f25eb369dc011161613894f01fd0a6ae85a09/trunk/xplanet-c++11.patch";
       sha256 = "0vldai78ixw49bxch774pps6pq4sp0p33qvkvxywcz7p8kzpg8q2";
     })
   ];

--- a/pkgs/applications/window-managers/openbox/default.nix
+++ b/pkgs/applications/window-managers/openbox/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     # Use fetchurl to avoid "fetchpatch: ignores file renames" #32084
     # This patch adds python3 support
     (fetchurl {
-      url = "https://git.archlinux.org/svntogit/community.git/plain/openbox/trunk/py3.patch?id=90cb57ef53d952bb6ab4c33a184f815bbe1791c0";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/90cb57ef53d952bb6ab4c33a184f815bbe1791c0/openbox/trunk/py3.patch";
       sha256 = "1ks99awlkhd5ph9kz94s1r6m1bfvh42g4rmxd14dyg5b421p1ljc";
     })
   ];

--- a/pkgs/development/libraries/gcc/libstdc++/5.nix
+++ b/pkgs/development/libraries/gcc/libstdc++/5.nix
@@ -19,13 +19,13 @@ stdenv.mkDerivation rec {
     ./no-sys-dirs.patch
     (fetchpatch {
       name = "siginfo.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/siginfo.patch?h=packages/libstdc%2B%2B5&id=e36ee8ed9bb5942db14cf6249a2ead14974a2bfa";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/e36ee8ed9bb5942db14cf6249a2ead14974a2bfa/trunk/siginfo.patch";
       sha256 = "15zldbm33yba293dgrgsbv3j332hkc3iqpyc8fa7zl42mh9qk22j";
       extraPrefix = "";
     })
     (fetchpatch {
       name = "gcc-3.4.3-no_multilib_amd64.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/gcc-3.4.3-no_multilib_amd64.patch?h=packages/libstdc%2B%2B5&id=e36ee8ed9bb5942db14cf6249a2ead14974a2bfa";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/e36ee8ed9bb5942db14cf6249a2ead14974a2bfa/trunk/gcc-3.4.3-no_multilib_amd64.patch";
       sha256 = "11m5lc51b0addhc4yq4rz0dwpv6k73rrj73wya3lqdk8rly6cjpm";
       extraPrefix = "";
     })

--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     (fetchurl {
       # 2020-06-19: NOTE: # Fix build with C++11
       # Close when https://github.com/TechSmith/mp4v2/pull/36 merged/closed.
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/libmp4v2-c++11.patch?id=203f5a72bc97ffe089b424c47b07dd9eaea35713";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/203f5a72bc97ffe089b424c47b07dd9eaea35713/trunk/libmp4v2-c++11.patch";
       sha256 = "0sbn0il7lmk77yrjyb4f0a3z3h8gsmdkscvz5n9hmrrrhrwf672w";
     })
   ];

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -81,7 +81,7 @@ let
       # https://bugreports.qt.io/browse/QTBUG-77037
       (fetchpatch {
         name = "fix-build-with-pulseaudio-13.0.patch";
-        url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
+        url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/fc77d6b3d5ec74e421b58f199efceb2593cbf951/trunk/qtbug-77037-workaround.patch";
         sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
       })
 

--- a/pkgs/development/libraries/science/math/lcalc/default.nix
+++ b/pkgs/development/libraries/science/math/lcalc/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
 
     (fetchpatch {
       name = "c++11.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/lcalc-c++11.patch?h=packages/lcalc&id=3607b97df5a8c231191115b0cb5c62426b339e71";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/3607b97df5a8c231191115b0cb5c62426b339e71/trunk/lcalc-c++11.patch";
       sha256 = "1ccrl61lv2vvx8ggldq54m5d0n1iy6mym7qz0i8nj6yj0dshnpk3";
     })
   ] ++ stdenv.lib.optional stdenv.isDarwin

--- a/pkgs/os-specific/linux/g15daemon/default.nix
+++ b/pkgs/os-specific/linux/g15daemon/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
 
   patches = let
     patch = fname: sha256: fetchurl rec {
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/${pname}-${version}-${fname}.patch?h=packages/${pname}";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/c0b0b6d4d6d7b79eca68123b20e0c9fb82e1c6e1/g15daemon/trunk/${pname}-${version}-${fname}.patch";
       name = "${fname}.patch";
       inherit sha256;
     };

--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -23,12 +23,12 @@ stdenv.mkDerivation {
       sha256 = "06ifgzbpjj4picpj17zgprsfi501zf4pp85qjjgn29i5rs291zni";
     })
     (fetchurl {
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/0005-gnu-efi-version-compatibility.patch?id=821c3da473d1399d930d5b4a086e46a4179eaa45";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/821c3da473d1399d930d5b4a086e46a4179eaa45/trunk/0005-gnu-efi-version-compatibility.patch";
       name = "0005-gnu-efi-version-compatibility.patch";
       sha256 = "1mz2idg8cwn0mvd3jixxynhkn7rhmi5fp8cc8zznh5f0ysfra446";
     })
     (fetchurl {
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/0025-reproducible-build.patch?id=821c3da473d1399d930d5b4a086e46a4179eaa45";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/821c3da473d1399d930d5b4a086e46a4179eaa45/trunk/0025-reproducible-build.patch";
       name = "0025-reproducible-build.patch";
       sha256 = "0qk6wc6z3648828y3961pn4pi7xhd20a6fqn6z1mnj22bbvzcxls";
     })

--- a/pkgs/tools/graphics/cuneiform/default.nix
+++ b/pkgs/tools/graphics/cuneiform/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   patches = [
   (fetchurl {
-    url = "https://git.archlinux.org/svntogit/community.git/plain/cuneiform/trunk/build-fix.patch?id=a2ec92f05de006b56d16ac6a6c370d54a554861a";
+    url = "https://raw.githubusercontent.com/archlinux/svntogit-community/a2ec92f05de006b56d16ac6a6c370d54a554861a/cuneiform/trunk/build-fix.patch";
     sha256 = "19cmrlx4khn30qqrpyayn7bicg8yi0wpz1x1bvqqrbvr3kwldxyj";
   })
   ];

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -3,8 +3,7 @@
 let
   xvfb_run = fetchurl {
     name = "xvfb-run";
-    # https://git.archlinux.org/svntogit/packages.git/?h=packages/xorg-server
-    url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/xvfb-run?h=packages/xorg-server&id=9cb733cefa92af3fca608fb051d5251160c9bbff";
+    url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/9cb733cefa92af3fca608fb051d5251160c9bbff/trunk/xvfb-run";
     sha256 = "1307mz4nr8ga3qz73i8hbcdphky75rq8lrvfk2zm4kmv6pkbk611";
   };
 in

--- a/pkgs/tools/networking/vde2/default.nix
+++ b/pkgs/tools/networking/vde2/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     # Fix build with openssl 1.1.0
     (fetchpatch {
       name = "vde_cryptcab-compile-against-openssl-1.1.0.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/vde_cryptcab-compile-against-openssl-1.1.0.patch?h=packages/vde2&id=15b11be49997fa94b603e366064690b7cc6bce61";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b11be49997fa94b603e366064690b7cc6bce61/trunk/vde_cryptcab-compile-against-openssl-1.1.0.patch";
       sha256 = "07z1yabwigq35mkwzqa934n7vjnjlqz5xfzq8cfj87lgyjjp00qi";
     })
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl [

--- a/pkgs/tools/networking/zssh/default.nix
+++ b/pkgs/tools/networking/zssh/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
     # Cargo-culted from Arch, returns “out of pty's” without it
     (fetchurl {
       name = "fix_use_ptmx_on_arch.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/fix_use_ptmx_on_arch.patch?h=packages/zssh&id=0a7c92543f9309856d02e31196f06d7c3eaa8b67";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/0a7c92543f9309856d02e31196f06d7c3eaa8b67/trunk/fix_use_ptmx_on_arch.patch";
       sha256 = "12daw9wpy58ql882zww945wk9cg2adwp8qsr5rvazx0xq0qawgbr";
     })
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
